### PR TITLE
fix grafana deployment issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ The prometheus-grafana-deployment.yaml is highly inspired from the Cilium's exam
 
 Expose the port on your local machine
 ```
-kubectl -n explorer port-forward service/prometheus --address 0.0.0.0 --address :: 9091:9090
+kubectl -n kubearmor port-forward service/prometheus --address 0.0.0.0 --address :: 9091:9090
 ```
 
 ### Grafana Access
 
 Expose the port on your local machine
 ```
-kubectl -n explorer port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
+kubectl -n kubearmor port-forward service/grafana --address 0.0.0.0 --address :: 3000:3000
 ```
 
 ---

--- a/deployments/prometheus/prometheus-grafana-deployment.yaml
+++ b/deployments/prometheus/prometheus-grafana-deployment.yaml
@@ -12,7 +12,7 @@ kind: ConfigMap
 metadata:
   labels:
     kubearmor-app: grafana
-  name: kubearmor-grafana-dashboard
+  name: grafana-config
   namespace: kubearmor
 data:
   config.yaml: |


### PR DESCRIPTION
Grafana was unable to deployed due to a minor mistake in the name of ConfigMap