### PR TITLE
update library version and container versions to make it work with latest version of Kubearmor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Builder
 
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.22-alpine3.20 AS builder
 
 WORKDIR /usr/src/kubearmor-prometheus-exporter
 
@@ -8,12 +8,12 @@ RUN apk update
 RUN apk add build-base
 
 COPY . .
-
+RUN go mod tidy
 RUN GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o kubearmor-prometheus-exporter main.go
 
 ### Make executable image
 
-FROM alpine:3.12
+FROM alpine:3.20.3
 
 COPY --from=builder /usr/src/kubearmor-prometheus-exporter/kubearmor-prometheus-exporter /kubearmor-prometheus-exporter
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/kubearmor/kubearmor-prometheus-exporter
 
-go 1.15
+go 1.21
 
 require (
-	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20210707153129-f4fba7cf59b6
-	github.com/prometheus/client_golang v1.11.0
-	google.golang.org/grpc v1.38.0
+	github.com/kubearmor/KubeArmor/protobuf		v0.0.0-20240920075411-bdb092b48b74
+	github.com/prometheus/client_golang v1.20.4
+	google.golang.org/grpc v1.67.0
 )


### PR DESCRIPTION
When trying this project with the latest version of KubeArmor, it seems that the protobuf definition used to create the metrics is outdated.

I have simply updated the version number to make it compatible with the latest version of Kuberarmor.